### PR TITLE
Add validation of mappings from doctrine_fluent.mappings configuration

### DIFF
--- a/src/DependencyInjection/DoctrineFluentMappingExtension.php
+++ b/src/DependencyInjection/DoctrineFluentMappingExtension.php
@@ -7,6 +7,7 @@ namespace Gordinskiy\DoctrineFluentMappingBundle\DependencyInjection;
 use Gordinskiy\DoctrineFluentMappingBundle\Exceptions\ConfigurationException;
 use Gordinskiy\DoctrineFluentMappingBundle\MappingLoaders\MappingLoader;
 use Gordinskiy\DoctrineFluentMappingBundle\MappingLoaders\MappingLocators\MappingLocator;
+use Gordinskiy\DoctrineFluentMappingBundle\Validators\MappingsValidator;
 use LaravelDoctrine\Fluent\FluentDriver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,6 +25,7 @@ class DoctrineFluentMappingExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
 
         $mappings = $config[Configuration::MAPPINGS_KEY];
+        MappingsValidator::isValid(...$mappings);
 
         if (!empty($config[Configuration::MAPPINGS_PATHS_KEY])) {
             $rootDir = (string) $container->getParameter('kernel.project_dir');

--- a/src/Exceptions/ConfigurationException.php
+++ b/src/Exceptions/ConfigurationException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gordinskiy\DoctrineFluentMappingBundle\Exceptions;
 
 use Exception;
+use LaravelDoctrine\Fluent\Mapping;
 
 class ConfigurationException extends Exception
 {
@@ -26,6 +27,13 @@ class ConfigurationException extends Exception
     {
         return new self(
             message: "Mapping directory is empty [$configDir]"
+        );
+    }
+
+    public static function invalidMappingClass(string $mappingCLass): self
+    {
+        return new self(
+            message: "Mapping class [$mappingCLass] must implement " . Mapping::class
         );
     }
 }

--- a/src/Validators/MappingsValidator.php
+++ b/src/Validators/MappingsValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gordinskiy\DoctrineFluentMappingBundle\Validators;
+
+use Gordinskiy\DoctrineFluentMappingBundle\Exceptions\ConfigurationException;
+use LaravelDoctrine\Fluent\Mapping;
+
+class MappingsValidator
+{
+    /**
+     * @param string ...$mappingClasses
+     *
+     * @throws ConfigurationException
+     */
+    public static function isValid(string ...$mappingClasses): void
+    {
+        foreach ($mappingClasses as $class) {
+            if (!in_array(Mapping::class, class_implements($class))) {
+                throw ConfigurationException::invalidMappingClass($class);
+            }
+        }
+    }
+}

--- a/tests/UnitTests/DependencyInjection/DoctrineFluentMappingExtensionTest.php
+++ b/tests/UnitTests/DependencyInjection/DoctrineFluentMappingExtensionTest.php
@@ -84,8 +84,8 @@ class DoctrineFluentMappingExtensionTest extends TestCase
                     ->addArgument(
                         [
                             OrderMapper::class,
-                            ProductMapper::class,
                             UserMapper::class,
+                            ProductMapper::class,
                             AnotherUser::class,
                         ]
                     ))

--- a/tests/UnitTests/MappingLoaderTest.php
+++ b/tests/UnitTests/MappingLoaderTest.php
@@ -27,8 +27,8 @@ class MappingLoaderTest extends TestCase
             expected: $loader->getAllEntityMappers(),
             actual: [
                 OrderMapper::class,
-                ProductMapper::class,
                 UserMapper::class,
+                ProductMapper::class,
             ]
         );
     }

--- a/tests/UnitTests/Validators/MappingsValidatorTest.php
+++ b/tests/UnitTests/Validators/MappingsValidatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gordinskiy\DoctrineFluentMappingBundle\Tests\UnitTests\Validators;
+
+use Gordinskiy\DoctrineFluentMappingBundle\Exceptions\ConfigurationException;
+use Gordinskiy\DoctrineFluentMappingBundle\Tests\Fixtures\Mappers\DirectoryWithSeveralMappers\OrderMapper;
+use Gordinskiy\DoctrineFluentMappingBundle\Validators\MappingsValidator;
+use LaravelDoctrine\Fluent\Mapping;
+use PHPUnit\Framework\TestCase;
+
+class MappingsValidatorTest extends TestCase
+{
+    public function test_validation_of_incorrect_class(): void
+    {
+        self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage(
+            "Mapping class [" . MappingsValidator::class . "] must implement " . Mapping::class
+        );
+        MappingsValidator::isValid(MappingsValidator::class);
+    }
+
+    public function test_validation_of_correct_class(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        MappingsValidator::isValid(OrderMapper::class);
+    }
+}


### PR DESCRIPTION
- [Throw exception if one of configured Mappers not implement any of Fluent Mapper Interfaces](https://github.com/gordinskiy/DoctrineFluentMappingBundle/issues/18)